### PR TITLE
enable and fix eslint recommended ruleset

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,9 +12,9 @@
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-unused-vars": [
-      "warn",
+      "error",
       {
-        "argsIgnorePattern": "^_",
+        "argsIgnorePattern": "^_|^props$",
         "ignoreRestSiblings": true
       }
     ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,15 @@
 {
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint"
+  ],
   "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
     "next/core-web-vitals",
     "prettier"
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off"
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,13 @@
     "prettier"
   ],
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "ignoreRestSiblings": true
+      }
+    ]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "next/core-web-vitals"
-}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
   "devDependencies": {
     "@types/node": "16.11.11",
     "@types/react": "17.0.37",
+    "@typescript-eslint/eslint-plugin": "5.5.0",
+    "@typescript-eslint/parser": "5.5.0",
     "eslint": "7.32.0",
     "eslint-config-next": "12.0.4",
     "eslint-config-prettier": "8.3.0",

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -6,7 +6,7 @@ import { ColumnsWrapper, DownloadAppButtons, PageHeader, PageScrollableContent, 
 import { Meta } from '~/components/Meta/Meta'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
-interface ServerProps extends Page {}
+type ServerProps = Page
 
 const keyPrefix = 'pages_about'
 

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -2,13 +2,11 @@ import { GetServerSideProps } from 'next'
 import { useTranslation } from 'next-i18next'
 import { Page } from '~/lib/utility/page'
 import { PV } from '~/resources'
-import { ColumnsWrapper, DownloadAppButtons, PageHeader, PageScrollableContent, SideContent } from '~/components'
+import { ColumnsWrapper, DownloadAppButtons, PageHeader, PageScrollableContent } from '~/components'
 import { Meta } from '~/components/Meta/Meta'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
 type ServerProps = Page
-
-const keyPrefix = 'pages_about'
 
 export default function About(props: ServerProps) {
   /* Initialize */

--- a/pages/clip/[clipId].tsx
+++ b/pages/clip/[clipId].tsx
@@ -13,8 +13,7 @@ import {
   PageHeader,
   PageScrollableContent,
   Pagination,
-  PodcastPageHeader,
-  SideContent
+  PodcastPageHeader
 } from '~/components'
 import { scrollToTopOfPageScrollableContent } from '~/components/PageScrollableContent/PageScrollableContent'
 import { calcListPageCount, prefixClipLabel } from '~/lib/utility/misc'

--- a/pages/episode/[episodeId].tsx
+++ b/pages/episode/[episodeId].tsx
@@ -12,9 +12,7 @@ import {
   Meta,
   PageHeader,
   PageScrollableContent,
-  Pagination,
-  PodcastPageHeader,
-  SideContent
+  Pagination
 } from '~/components'
 import { scrollToTopOfPageScrollableContent } from '~/components/PageScrollableContent/PageScrollableContent'
 import { calcListPageCount } from '~/lib/utility/misc'
@@ -58,7 +56,7 @@ export default function Episode({
 }: ServerProps) {
   /* Initialize */
 
-  const { id, podcast } = serverEpisode
+  const { id } = serverEpisode
   const { t } = useTranslation()
   const [filterState, setFilterState] = useState({
     clipsFilterPage: serverClipsFilterPage,

--- a/pages/history.tsx
+++ b/pages/history.tsx
@@ -13,8 +13,7 @@ import {
   PageHeader,
   PageScrollableContent,
   Pagination,
-  scrollToTopOfPageScrollableContent,
-  SideContent
+  scrollToTopOfPageScrollableContent
 } from '~/components'
 import { Page } from '~/lib/utility/page'
 import { PV } from '~/resources'

--- a/pages/membership.tsx
+++ b/pages/membership.tsx
@@ -15,7 +15,7 @@ import {
 } from '~/components'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
-interface ServerProps extends Page {}
+type ServerProps = Page
 
 const keyPrefix = 'pages_membership'
 

--- a/pages/membership.tsx
+++ b/pages/membership.tsx
@@ -10,14 +10,11 @@ import {
   MembershipStatus,
   Meta,
   PageHeader,
-  PageScrollableContent,
-  SideContent
+  PageScrollableContent
 } from '~/components'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
 type ServerProps = Page
-
-const keyPrefix = 'pages_membership'
 
 export default function Membership(props: ServerProps) {
   /* Initialize */

--- a/pages/my-profile.tsx
+++ b/pages/my-profile.tsx
@@ -6,7 +6,7 @@ import { PV } from '~/resources'
 import { MessageWithAction, Meta, PageHeader, PageScrollableContent } from '~/components'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
-interface ServerProps extends Page {}
+type ServerProps = Page
 
 const keyPrefix = 'pages_my_profile'
 

--- a/pages/my-profile.tsx
+++ b/pages/my-profile.tsx
@@ -8,8 +8,6 @@ import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
 type ServerProps = Page
 
-const keyPrefix = 'pages_my_profile'
-
 export default function MyProfile(props: ServerProps) {
   /* Initialize */
 

--- a/pages/payment/paypal-confirming/[paymentID].tsx
+++ b/pages/payment/paypal-confirming/[paymentID].tsx
@@ -9,7 +9,7 @@ import { Icon, Meta, PageHeader, PageScrollableContent } from '~/components'
 import { useTranslation } from 'react-i18next'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
-interface ServerProps extends Page {}
+type ServerProps = Page
 
 const keyPrefix = 'pages_payment_paypal_confirming'
 let isCheckingInterval = null

--- a/pages/payment/paypal-confirming/[paymentID].tsx
+++ b/pages/payment/paypal-confirming/[paymentID].tsx
@@ -11,7 +11,6 @@ import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
 type ServerProps = Page
 
-const keyPrefix = 'pages_payment_paypal_confirming'
 let isCheckingInterval = null
 
 export default function PaymentPayPalConfirming(props: ServerProps) {

--- a/pages/playlist/[playlistId].tsx
+++ b/pages/playlist/[playlistId].tsx
@@ -39,7 +39,7 @@ export default function Playlist({ serverPlaylist, serverPlaylistSortedItems }: 
   const [playlist, setPlaylist] = useState<Playlist>(serverPlaylist)
   const [playlistSortedItems, setPlaylistSortedItems] = useState<[Episode | MediaRef]>(serverPlaylistSortedItems)
   const [editingPlaylistTitle, setEditingPlaylistTitle] = useState<string>(serverPlaylist.title)
-  const [editingPlaylistIsPublic, setEditingPlaylistIsPublic] = useState<boolean>(serverPlaylist.isPublic)
+  const [editingPlaylistIsPublic] = useState<boolean>(serverPlaylist.isPublic)
   const [userInfo] = useOmniAural('session.userInfo')
 
   /* Function Helpers */

--- a/pages/podcast/[podcastId].tsx
+++ b/pages/podcast/[podcastId].tsx
@@ -271,8 +271,8 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
   let serverEpisodes = []
   let serverEpisodesPageCount = 0
-  let serverClips = []
-  let serverClipsPageCount = 0
+  const serverClips = []
+  const serverClipsPageCount = 0
   if (serverFilterType === PV.Filters.type._episodes) {
     const response = await getEpisodesByQuery({
       podcastIds: podcastId,

--- a/pages/profile/[profileId].tsx
+++ b/pages/profile/[profileId].tsx
@@ -55,7 +55,7 @@ export default function Profile({
   const [listDataCount, setListDataCount] = useState<number>(serverUserListDataCount)
   const [isEditing, setIsEditing] = useState<boolean>(false)
   const [editingUserName, setEditingUserName] = useState<string>(serverUser.name)
-  const [editingUserIsPublic, setEditingUserIsPublic] = useState<boolean>(serverUser.isPublic)
+  const [editingUserIsPublic] = useState<boolean>(serverUser.isPublic)
   const initialRender = useRef(true)
   const pageSubTitle =
     filterType === PV.Filters.type._clips

--- a/pages/profiles.tsx
+++ b/pages/profiles.tsx
@@ -9,7 +9,6 @@ import {
   PageHeader,
   PageScrollableContent,
   Pagination,
-  PlaylistListItem,
   scrollToTopOfPageScrollableContent
 } from '~/components'
 import { Page } from '~/lib/utility/page'
@@ -45,7 +44,7 @@ export default function Profiles({ serverFilterPage, serverUsers, serverUsersCou
         initialRender.current = false
       } else {
         OmniAural.pageIsLoadingShow()
-        const [newListData, newListCount] = await clientQueryUsers()
+        const [newListData] = await clientQueryUsers()
         setUsersListData(newListData)
         scrollToTopOfPageScrollableContent()
         OmniAural.pageIsLoadingHide()

--- a/pages/queue.tsx
+++ b/pages/queue.tsx
@@ -11,8 +11,7 @@ import {
   MessageWithAction,
   Meta,
   PageHeader,
-  PageScrollableContent,
-  SideContent
+  PageScrollableContent
 } from '~/components'
 import { Page } from '~/lib/utility/page'
 import { PV } from '~/resources'

--- a/pages/queue.tsx
+++ b/pages/queue.tsx
@@ -19,7 +19,7 @@ import { PV } from '~/resources'
 import { isNowPlayingItemMediaRef } from '~/lib/utility/typeHelpers'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
-interface ServerProps extends Page {}
+type ServerProps = Page
 
 const keyPrefix = 'pages_queue'
 

--- a/pages/reset-password.tsx
+++ b/pages/reset-password.tsx
@@ -7,7 +7,7 @@ import { PV } from '~/resources'
 import { resetPassword } from '~/services/auth'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
-interface ServerProps extends Page {}
+type ServerProps = Page
 
 const keyPrefix = 'pages_reset_password'
 

--- a/pages/reset-password.tsx
+++ b/pages/reset-password.tsx
@@ -9,8 +9,6 @@ import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
 type ServerProps = Page
 
-const keyPrefix = 'pages_reset_password'
-
 export default function ResetPassword(props: ServerProps) {
   /* Initialize */
 

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -139,8 +139,7 @@ export default function Search(props: ServerProps) {
 /* Server-Side Logic */
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  const { req, locale } = ctx
-  const { cookies } = req
+  const { locale } = ctx
 
   const defaultServerProps = await getDefaultServerSideProps(ctx, locale)
 

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -17,7 +17,7 @@ import { getPodcastsByQuery } from '~/services/podcast'
 import { scrollToTopOfPageScrollableContent } from '~/components/PageScrollableContent/PageScrollableContent'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
-interface ServerProps extends Page {}
+type ServerProps = Page
 
 const keyPrefix = 'pages_search'
 

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -2,12 +2,10 @@ import { GetServerSideProps } from 'next'
 import { useTranslation } from 'next-i18next'
 import { Page } from '~/lib/utility/page'
 import { PV } from '~/resources'
-import { ColumnsWrapper, Meta, PageHeader, PageScrollableContent, SideContent } from '~/components'
+import { ColumnsWrapper, Meta, PageHeader, PageScrollableContent } from '~/components'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
 type ServerProps = Page
-
-const keyPrefix = 'pages_terms'
 
 export default function Terms(props: ServerProps) {
   /* Initialize */

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -5,7 +5,7 @@ import { PV } from '~/resources'
 import { ColumnsWrapper, Meta, PageHeader, PageScrollableContent, SideContent } from '~/components'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 
-interface ServerProps extends Page {}
+type ServerProps = Page
 
 const keyPrefix = 'pages_terms'
 

--- a/src/components/ClipInfo/ClipInfo.tsx
+++ b/src/components/ClipInfo/ClipInfo.tsx
@@ -1,7 +1,7 @@
 import { useOmniAural } from 'omniaural'
 import { Episode, MediaRef } from 'podverse-shared'
 import { useTranslation } from 'react-i18next'
-import { MediaItemControls, PVLink, TruncatedText } from '~/components'
+import { MediaItemControls, PVLink } from '~/components'
 import { readableDate } from '~/lib/utility/date'
 import { getClipTitle, getEpisodeTitle } from '~/lib/utility/misc'
 import { PV } from '~/resources'

--- a/src/components/DownloadAppButtons/DownloadAppButtons.tsx
+++ b/src/components/DownloadAppButtons/DownloadAppButtons.tsx
@@ -2,7 +2,7 @@ import { PV } from '~/resources'
 
 type Props = unknown
 
-export const DownloadAppButtons = () => {
+export const DownloadAppButtons = (props: Props) => {
   return (
     <div className='download-app-buttons'>
       <a className='download-on-the-app-store no-radius' href={PV.Config.APP_DOWNLOAD_ON_THE_APP_STORE_URL} />

--- a/src/components/DownloadAppButtons/DownloadAppButtons.tsx
+++ b/src/components/DownloadAppButtons/DownloadAppButtons.tsx
@@ -1,6 +1,6 @@
 import { PV } from '~/resources'
 
-type Props = {}
+type Props = unknown
 
 export const DownloadAppButtons = () => {
   return (

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -18,7 +18,7 @@ type Props = {
 }
 
 const contentRenderer = (props: Props, t: any) => {
-  const { faIcon, hideCaret, options, selectedKey, text } = props
+  const { faIcon, options, selectedKey, text } = props
   const selectedOption = options?.find((option) => option.key === selectedKey)
   const finalText = text || selectedOption?.label
 

--- a/src/components/EpisodePageHeader/EpisodePageHeader.tsx
+++ b/src/components/EpisodePageHeader/EpisodePageHeader.tsx
@@ -1,5 +1,5 @@
 import { useOmniAural } from 'omniaural'
-import type { Episode, Podcast } from 'podverse-shared'
+import type { Episode } from 'podverse-shared'
 import { useTranslation } from 'react-i18next'
 import { generateAuthorText } from '~/lib/utility/author'
 import { generateCategoryNodes } from '~/lib/utility/category'

--- a/src/components/HorizontalNavBar/HorizontalNavBar.tsx
+++ b/src/components/HorizontalNavBar/HorizontalNavBar.tsx
@@ -1,13 +1,12 @@
 import { faChevronLeft, faChevronRight, faMoon, faSun, faUserCircle } from '@fortawesome/free-solid-svg-icons'
 import { faUserCircle as faUserCircleRegular } from '@fortawesome/free-regular-svg-icons'
 import { useRouter } from 'next/router'
-import OmniAural, { useOmniAural } from 'omniaural'
+import { useOmniAural } from 'omniaural'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCookies } from 'react-cookie'
 import { ButtonCircle, Dropdown, SwitchWithIcons } from '~/components'
 import { PV } from '~/resources'
-import { logOut } from '~/services/auth'
 
 type Props = {
   serverCookies: any
@@ -15,7 +14,7 @@ type Props = {
 
 export const HorizontalNavBar = ({ serverCookies }: Props) => {
   const [lightModeChecked, setLightModeChecked] = useState<boolean>(serverCookies.lightMode)
-  const [cookies, setCookie, removeCookie] = useCookies([])
+  const [, setCookie, removeCookie] = useCookies([])
   const router = useRouter()
   const { t } = useTranslation()
   const [userInfo] = useOmniAural('session.userInfo')

--- a/src/components/HorizontalNavBar/HorizontalNavBar.tsx
+++ b/src/components/HorizontalNavBar/HorizontalNavBar.tsx
@@ -58,7 +58,7 @@ export const HorizontalNavBar = ({ serverCookies }: Props) => {
         </div>
         <div className='navbar-secondary__dropdown'>
           <Dropdown
-            faIcon={!!userInfo ? faUserCircle : faUserCircleRegular}
+            faIcon={userInfo ? faUserCircle : faUserCircleRegular}
             onChange={(selected) => PV.NavBar.dropdownOnChange(selected, router, userInfo)}
             options={dropdownItems}
           />

--- a/src/components/MakeClip/MakeClipModal.tsx
+++ b/src/components/MakeClip/MakeClipModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import Modal from 'react-modal'
 import { ButtonClose, MakeClipForm } from '~/components'
 
-type Props = {}
+type Props = unknown
 
 export const MakeClipModal = (props: Props) => {
   const { t } = useTranslation()

--- a/src/components/MakeClip/MakeClipModal.tsx
+++ b/src/components/MakeClip/MakeClipModal.tsx
@@ -1,12 +1,10 @@
 import OmniAural, { useOmniAural } from 'omniaural'
-import { useTranslation } from 'react-i18next'
 import Modal from 'react-modal'
 import { ButtonClose, MakeClipForm } from '~/components'
 
 type Props = unknown
 
 export const MakeClipModal = (props: Props) => {
-  const { t } = useTranslation()
   const [makeClip] = useOmniAural('makeClip')
 
   const _onRequestClose = OmniAural.makeClipHide

--- a/src/components/MakeClip/MakeClipSuccessModal.tsx
+++ b/src/components/MakeClip/MakeClipSuccessModal.tsx
@@ -1,7 +1,7 @@
 import OmniAural, { useOmniAural } from 'omniaural'
 import { useTranslation } from 'react-i18next'
 import Modal from 'react-modal'
-import { ButtonClose, ButtonRectangle, TextInputCopy } from '~/components'
+import { ButtonClose, TextInputCopy } from '~/components'
 
 type Props = unknown
 

--- a/src/components/MakeClip/MakeClipSuccessModal.tsx
+++ b/src/components/MakeClip/MakeClipSuccessModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import Modal from 'react-modal'
 import { ButtonClose, ButtonRectangle, TextInputCopy } from '~/components'
 
-type Props = {}
+type Props = unknown
 
 export const MakeClipSuccessModal = (props: Props) => {
   const [makeClip] = useOmniAural('makeClip')

--- a/src/components/MediaItemControls/MediaItemControls.tsx
+++ b/src/components/MediaItemControls/MediaItemControls.tsx
@@ -52,7 +52,7 @@ export const MediaItemControls = ({
   const { t } = useTranslation()
   let pubDate = null
   let timeInfo = null
-  let timeRemaining = null
+  const timeRemaining = null
   let completed = false
   if (mediaRef) {
     pubDate = readableDate(mediaRef.episode.pubDate)

--- a/src/components/MembershipStatus/MembershipStatus.tsx
+++ b/src/components/MembershipStatus/MembershipStatus.tsx
@@ -2,7 +2,7 @@ import { useOmniAural } from 'omniaural'
 import { useTranslation } from 'react-i18next'
 import { isBeforeDate } from '~/lib/utility/date'
 
-type Props = {}
+type Props = unknown
 
 export const MembershipStatus = (props: Props) => {
   const { t } = useTranslation()

--- a/src/components/Modals/AddToPlaylistModal/AddToPlaylistModal.tsx
+++ b/src/components/Modals/AddToPlaylistModal/AddToPlaylistModal.tsx
@@ -11,7 +11,7 @@ import {
   getLoggedInUserPlaylists
 } from '~/services/playlist'
 
-type Props = {}
+type Props = unknown
 
 const keyPrefix = '_addToPlaylist'
 

--- a/src/components/Modals/AddToPlaylistModal/AddToPlaylistModal.tsx
+++ b/src/components/Modals/AddToPlaylistModal/AddToPlaylistModal.tsx
@@ -3,7 +3,7 @@ import type { Playlist } from 'podverse-shared'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Modal from 'react-modal'
-import { ButtonClose, ButtonLink, ButtonRectangle, PlaylistListItem } from '~/components'
+import { ButtonClose, ButtonLink } from '~/components'
 import {
   addOrRemovePlaylistItemEpisode,
   addOrRemovePlaylistItemMediaRef,
@@ -61,7 +61,7 @@ export const AddToPlaylistModal = (props: Props) => {
   const _onAfterOpen = async () => {
     OmniAural.pageIsLoadingShow()
     const response = await getLoggedInUserPlaylists()
-    const [playlists, playlistsCount] = response
+    const [playlists] = response
     setPlaylists(playlists)
     OmniAural.pageIsLoadingHide()
   }

--- a/src/components/Modals/Auth/ForgotPasswordModal.tsx
+++ b/src/components/Modals/Auth/ForgotPasswordModal.tsx
@@ -5,7 +5,7 @@ import Modal from 'react-modal'
 import { ButtonClose, ButtonRectangle, TextInput } from '~/components'
 import { sendResetPassword } from '~/services/auth'
 
-type Props = {}
+type Props = unknown
 
 export const ForgotPasswordModal = (props: Props) => {
   const [forgotPassword] = useOmniAural('modals.forgotPassword')

--- a/src/components/Modals/Auth/LoginModal.tsx
+++ b/src/components/Modals/Auth/LoginModal.tsx
@@ -5,7 +5,7 @@ import Modal from 'react-modal'
 import { ButtonClose, ButtonLink, ButtonRectangle, TextInput } from '~/components'
 import { login as loginService } from '~/services/auth'
 
-type Props = {}
+type Props = unknown
 
 export const LoginModal = (props: Props) => {
   const [login] = useOmniAural('modals.login')

--- a/src/components/Modals/Auth/LoginToAlertModal.tsx
+++ b/src/components/Modals/Auth/LoginToAlertModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import Modal from 'react-modal'
 import { ButtonClose, ButtonRectangle } from '~/components'
 
-type Props = {}
+type Props = unknown
 
 export const LoginToAlertModal = (props: Props) => {
   const [loginToAlert] = useOmniAural('modals.loginToAlert')

--- a/src/components/Modals/Auth/SignUpModal.tsx
+++ b/src/components/Modals/Auth/SignUpModal.tsx
@@ -5,7 +5,7 @@ import Modal from 'react-modal'
 import { ButtonClose, PasswordInputs } from '~/components'
 import { signUp as signUpService } from '~/services/auth'
 
-type Props = {}
+type Props = unknown
 
 export const SignUpModal = (props: Props) => {
   const [signUp] = useOmniAural('modals.signUp')

--- a/src/components/Modals/Auth/VerifyEmailModal.tsx
+++ b/src/components/Modals/Auth/VerifyEmailModal.tsx
@@ -5,7 +5,7 @@ import Modal from 'react-modal'
 import { ButtonClose, ButtonRectangle } from '~/components'
 import { sendVerification } from '~/services/auth'
 
-type Props = {}
+type Props = unknown
 
 export const VerifyEmailModal = (props: Props) => {
   const [verifyEmail] = useOmniAural('modals.verifyEmail')

--- a/src/components/Modals/CheckoutModal/CheckoutModal.tsx
+++ b/src/components/Modals/CheckoutModal/CheckoutModal.tsx
@@ -2,7 +2,7 @@ import OmniAural, { useOmniAural } from 'omniaural'
 import Modal from 'react-modal'
 import { ButtonClose, PayPalButton } from '~/components'
 
-type Props = {}
+type Props = unknown
 
 export const CheckoutModal = (props: Props) => {
   const [checkout] = useOmniAural('modals.checkout')

--- a/src/components/Modals/Modals.tsx
+++ b/src/components/Modals/Modals.tsx
@@ -10,7 +10,7 @@ import {
 } from '~/components'
 import { MakeClipSuccessModal } from '../MakeClip/MakeClipSuccessModal'
 
-type Props = {}
+type Props = unknown
 
 export const Modals = (props: Props) => {
   return (

--- a/src/components/NavBar/Mobile/MobileNavBar.tsx
+++ b/src/components/NavBar/Mobile/MobileNavBar.tsx
@@ -32,7 +32,7 @@ export const MobileNavBar = (props: Props) => {
         <div className='right-wrapper'>
           <div className='dropdown'>
             <Dropdown
-              faIcon={!!userInfo ? faUserCircle : faUserCircleRegular}
+              faIcon={userInfo ? faUserCircle : faUserCircleRegular}
               onChange={(selected) => PV.NavBar.dropdownOnChange(selected, router, userInfo)}
               options={dropdownItems}
             />

--- a/src/components/NavBar/Mobile/MobileNavBar.tsx
+++ b/src/components/NavBar/Mobile/MobileNavBar.tsx
@@ -8,7 +8,7 @@ import { PV } from '~/resources'
 import { useState } from 'react'
 import { MobileNavMenuModal } from './MobileNavMenuModal'
 
-type Props = {}
+type Props = unknown
 
 export const MobileNavBar = (props: Props) => {
   const router = useRouter()

--- a/src/components/NavBar/Mobile/MobileNavMenuModal.tsx
+++ b/src/components/NavBar/Mobile/MobileNavMenuModal.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router'
 import { useOmniAural } from 'omniaural'
 import { useTranslation } from 'react-i18next'
 import Modal from 'react-modal'
-import { ButtonClose, NavBarSectionHeader } from '~/components'
+import { ButtonClose } from '~/components'
 import { PV } from '~/resources'
 import { MobileNavMenuLink } from './MobileNavMenuLink'
 

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -5,9 +5,9 @@ import { useOmniAural } from 'omniaural'
 import { NavBarBrand, NavBarLink, NavBarSectionHeader } from '~/components'
 import { PV } from '~/resources'
 
-type Props = {}
+type Props = unknown
 
-export const NavBar = ({}: Props) => {
+export const NavBar = (props: Props) => {
   const router = useRouter()
   const { t } = useTranslation()
   const [userInfo] = useOmniAural('session.userInfo')

--- a/src/components/PageLoadingOverlay/PageLoadingOverlay.tsx
+++ b/src/components/PageLoadingOverlay/PageLoadingOverlay.tsx
@@ -2,7 +2,7 @@ import { faSpinner } from '@fortawesome/free-solid-svg-icons'
 import { useOmniAural } from 'omniaural'
 import { Icon } from '~/components'
 
-type Props = {}
+type Props = unknown
 
 export const PageLoadingOverlay = (props: Props) => {
   const [isLoading] = useOmniAural('page.isLoading')

--- a/src/components/PayPalButton/PayPalButton.tsx
+++ b/src/components/PayPalButton/PayPalButton.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { PV } from '~/resources'
 import { createPayPalOrder } from '~/services/paypal'
 
-type Props = {}
+type Props = unknown
 
 let PayPalButtonFromLibrary: any = null
 

--- a/src/components/Player/Mobile/MobilePlayer.tsx
+++ b/src/components/Player/Mobile/MobilePlayer.tsx
@@ -7,7 +7,7 @@ import { getClipTitle } from '~/lib/utility/misc'
 import { PV } from '~/resources'
 import { playerPause, playerPlay, playerSeekTo } from '~/services/player/player'
 
-type Props = {}
+type Props = unknown
 
 export const MobilePlayer = (props: Props) => {
   const [player] = useOmniAural('player')

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -10,7 +10,7 @@ type Props = {}
 export const Player = ({}: Props) => {
   const [player] = useOmniAural('player')
 
-  const mainPlayerStyle = classnames('player', !!player.show ? '' : 'display-none')
+  const mainPlayerStyle = classnames('player', player.show ? '' : 'display-none')
 
   if (!player?.currentNowPlayingItem) {
     return null

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -5,9 +5,9 @@ import { PlayerItemInfo } from './PlayerItemInfo'
 import { PlayerItemButtons } from './PlayerItemOptions'
 import { PlayerItemProgress } from './PlayerItemProgress'
 
-type Props = {}
+type Props = unknown
 
-export const Player = ({}: Props) => {
+export const Player = (props: Props) => {
   const [player] = useOmniAural('player')
 
   const mainPlayerStyle = classnames('player', player.show ? '' : 'display-none')

--- a/src/components/Player/PlayerAPI/PlayerAPI.tsx
+++ b/src/components/Player/PlayerAPI/PlayerAPI.tsx
@@ -1,6 +1,6 @@
 import { PlayerAPIAudio } from './PlayerAPIAudio'
 
-type Props = {}
+type Props = unknown
 
 export const PlayerAPI = (props: Props) => {
   /* Never initialize PlayerAPIs on the server-side. */

--- a/src/components/Player/PlayerAPI/PlayerAPIAudio.tsx
+++ b/src/components/Player/PlayerAPI/PlayerAPIAudio.tsx
@@ -9,7 +9,7 @@ import { enrichChapterDataForPlayer, handleChapterUpdateInterval } from '~/servi
 import { generateChapterFlagPositions, setClipFlagPositions } from '~/services/player/playerFlags'
 import { addOrUpdateHistoryItemOnServer } from '~/services/userHistoryItem'
 
-type Props = {}
+type Props = unknown
 
 export const PlayerAPIAudio = (props: Props) => {
   const [player] = useOmniAural('player')

--- a/src/components/Player/PlayerAPI/PlayerAPIAudio.tsx
+++ b/src/components/Player/PlayerAPI/PlayerAPIAudio.tsx
@@ -64,7 +64,7 @@ export const PlayerAPIAudio = (props: Props) => {
 
     if (currentNowPlayingItem.episodeChaptersUrl) {
       const data = await retrieveLatestChaptersForEpisodeId(currentNowPlayingItem.episodeId)
-      const [chapters, chaptersCount] = data
+      const [chapters] = data
       const enrichedChapters = enrichChapterDataForPlayer(chapters, duration)
       const chapterFlagPositions = generateChapterFlagPositions(enrichedChapters, duration)
       OmniAural.setChapterFlagPositions(chapterFlagPositions)

--- a/src/components/Player/PlayerFullView.tsx
+++ b/src/components/Player/PlayerFullView.tsx
@@ -28,7 +28,7 @@ export const PlayerFullView = ({ nowPlayingItem }: Props) => {
 
   const clipTitle = getClipTitle(t, nowPlayingItem.clipTitle, nowPlayingItem.episodeTitle)
 
-  let clipTimeInfo = readableClipTime(nowPlayingItem.clipStartTime, nowPlayingItem.clipEndTime)
+  const clipTimeInfo = readableClipTime(nowPlayingItem.clipStartTime, nowPlayingItem.clipEndTime)
 
   return (
     <div className='player-full-view'>

--- a/src/components/Player/PlayerItemOptions.tsx
+++ b/src/components/Player/PlayerItemOptions.tsx
@@ -5,7 +5,7 @@ import { Slider } from '../Slider/Slider'
 import { playerMute, playerNextSpeed, playerSetVolume, playerUnmute } from '~/services/player/player'
 import { modalsAddToPlaylistShowOrAlert } from '~/state/modals/addToPlaylist/actions'
 
-type Props = {}
+type Props = unknown
 
 export const PlayerItemButtons = (props: Props) => {
   const [player] = useOmniAural('player')

--- a/src/components/Player/PlayerItemProgress.tsx
+++ b/src/components/Player/PlayerItemProgress.tsx
@@ -3,7 +3,7 @@ import { useOmniAural } from 'omniaural'
 import { PlayerProgressButtons } from './controls/PlayerProgressButtons'
 import { ProgressBar } from './controls/ProgressBar'
 
-type Props = {}
+type Props = unknown
 
 export const PlayerItemProgress = (props: Props) => {
   const [player] = useOmniAural('player')

--- a/src/components/PlaylistPageHeader/PlaylistPageHeader.tsx
+++ b/src/components/PlaylistPageHeader/PlaylistPageHeader.tsx
@@ -1,11 +1,9 @@
-import { faGlobe, faLink } from '@fortawesome/free-solid-svg-icons'
 import { useRouter } from 'next/router'
 import OmniAural, { useOmniAural } from 'omniaural'
 import type { Playlist } from 'podverse-shared'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ButtonRectangle, Dropdown, TextInput } from '~/components'
-import { PV } from '~/resources'
+import { ButtonRectangle, TextInput } from '~/components'
 import { deletePlaylistOnServer, toggleSubscribeToPlaylistOnServer } from '~/services/playlist'
 
 type Props = {
@@ -19,7 +17,6 @@ type Props = {
 }
 
 export const PlaylistPageHeader = ({
-  handleChangeIsPublic,
   handleEditCancel,
   handleEditSave,
   handleEditStart,
@@ -30,7 +27,7 @@ export const PlaylistPageHeader = ({
   const router = useRouter()
   const { t } = useTranslation()
   const [userInfo] = useOmniAural('session.userInfo')
-  const [isDeleting, setIsDeleting] = useState<boolean>(false)
+  const [, setIsDeleting] = useState<boolean>(false)
   const title = playlist?.title || t('untitledPlaylist')
   const ownerName = playlist?.owner?.name || t('Anonymous')
   const itemCount = playlist?.itemCount || 0

--- a/src/components/PodcastPageHeader/PodcastPageHeader.tsx
+++ b/src/components/PodcastPageHeader/PodcastPageHeader.tsx
@@ -1,5 +1,5 @@
 import { useOmniAural } from 'omniaural'
-import type { Episode, Podcast } from 'podverse-shared'
+import type { Podcast } from 'podverse-shared'
 import { useTranslation } from 'react-i18next'
 import { generateAuthorText } from '~/lib/utility/author'
 import { generateCategoryNodes } from '~/lib/utility/category'

--- a/src/components/ProfileListItem/ProfileListItem.tsx
+++ b/src/components/ProfileListItem/ProfileListItem.tsx
@@ -1,4 +1,3 @@
-import { useOmniAural } from 'omniaural'
 import { User } from 'podverse-shared'
 import { useTranslation } from 'react-i18next'
 import { PVLink } from '~/components'

--- a/src/lib/utility/copyToClipboard.ts
+++ b/src/lib/utility/copyToClipboard.ts
@@ -4,7 +4,7 @@
   https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
 */
 function fallbackCopyTextToClipboard(text) {
-  var textArea = document.createElement('textarea')
+  const textArea = document.createElement('textarea')
   textArea.value = text
 
   // Avoid scrolling to bottom
@@ -17,8 +17,8 @@ function fallbackCopyTextToClipboard(text) {
   textArea.select()
 
   try {
-    var successful = document.execCommand('copy')
-    var msg = successful ? 'successful' : 'unsuccessful'
+    const successful = document.execCommand('copy')
+    const msg = successful ? 'successful' : 'unsuccessful'
     console.log('Fallback: Copying text command was ' + msg)
   } catch (err) {
     console.error('Fallback: Oops, unable to copy', err)

--- a/src/lib/utility/misc.tsx
+++ b/src/lib/utility/misc.tsx
@@ -1,4 +1,4 @@
-import { Episode, MediaRef, Podcast } from 'podverse-shared'
+import { Episode, Podcast } from 'podverse-shared'
 import { PV } from '~/resources'
 
 export const calcListPageCount = (itemCount: number) => {

--- a/src/lib/utility/time.ts
+++ b/src/lib/utility/time.ts
@@ -1,5 +1,3 @@
-import { useTranslation } from 'react-i18next'
-
 export function validateHHMMSSString(hhmmss: string) {
   const regex = new RegExp(
     // eslint-disable-next-line max-len

--- a/src/lib/utility/validation.tsx
+++ b/src/lib/utility/validation.tsx
@@ -1,4 +1,4 @@
-const passwordValidator = require('password-validator')
+import passwordValidator from 'password-validator'
 
 const schema = new passwordValidator()
 

--- a/src/services/player/player.tsx
+++ b/src/services/player/player.tsx
@@ -49,10 +49,8 @@ export const playerCheckIfCurrentlyPlaying = () => {
   let isCurrentlyPlaying = false
   if (audioCheckIfCurrentlyPlaying()) {
     isCurrentlyPlaying = true
-  } else if (false) {
-    // handle video
-    isCurrentlyPlaying = true
   }
+
   return isCurrentlyPlaying
 }
 

--- a/src/services/player/player.tsx
+++ b/src/services/player/player.tsx
@@ -351,7 +351,7 @@ export const playerPlayNextChapterOrQueueItem = async () => {
 
 export const playerPlayNextFromQueue = async () => {
   const nextNowPlayingItem = await getNextFromQueue()
-  if (!!nextNowPlayingItem) {
+  if (nextNowPlayingItem) {
     const shouldPlay = true
     playerLoadNowPlayingItem(nextNowPlayingItem, shouldPlay)
   }

--- a/src/services/player/playerChapters.tsx
+++ b/src/services/player/playerChapters.tsx
@@ -4,7 +4,7 @@ import { unstable_batchedUpdates } from 'react-dom'
 import { playerGetDuration, playerGetPosition } from './player'
 import { setHighlightedFlagPositionsForChapter } from './playerFlags'
 
-let chapterUpdateInterval = null
+const chapterUpdateInterval = null
 
 export const clearChapterUpdateInterval = () => {
   if (chapterUpdateInterval) {

--- a/src/services/podcast.tsx
+++ b/src/services/podcast.tsx
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { PV } from '~/resources'
 import { request } from '~/services/request'
 

--- a/src/services/request.tsx
+++ b/src/services/request.tsx
@@ -9,7 +9,7 @@ type PVRequest = {
   headers?: any
   method?: string
   opts?: any
-  query?: {}
+  query?: Record<string, unknown>
   withCredentials?: boolean
 }
 
@@ -32,10 +32,6 @@ export const request = async (req: PVRequest) => {
     ...(withCredentials ? { withCredentials: true } : {})
   }
 
-  try {
-    const response = await axios(axiosRequest)
-    return response
-  } catch (error) {
-    throw error
-  }
+  const response = await axios(axiosRequest)
+  return response
 }

--- a/src/services/userQueueItem.tsx
+++ b/src/services/userQueueItem.tsx
@@ -96,7 +96,7 @@ export const getNextFromQueue = async () => {
   const userInfo = OmniAural.state.session.userInfo.value()
   let item = null
 
-  if (!!userInfo) {
+  if (userInfo) {
     const data = await getNextFromQueueFromServer()
     if (data) {
       const { nextItem } = data

--- a/src/state/historyItemsIndex/actions.tsx
+++ b/src/state/historyItemsIndex/actions.tsx
@@ -1,8 +1,8 @@
 import OmniAural from 'omniaural'
 
 type HistoryItemsIndex = {
-  episodes: {}
-  mediaRefs: {}
+  episodes: Record<string, unknown>
+  mediaRefs: Record<string, unknown>
 }
 
 const clearHistoryItemsIndex = () => {

--- a/src/state/userQueueItems/actions.ts
+++ b/src/state/userQueueItems/actions.ts
@@ -23,7 +23,7 @@ const removeQueueItemsAll = async () => {
 }
 
 const setLatestUserQueueItems = async () => {
-  const userQueueItems = await getQueueItemsFromServer()
+  await getQueueItemsFromServer()
 }
 
 const setUserQueueItems = async (userQueueItems: UserQueueItem) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -434,6 +434,11 @@
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
 
+"@types/json-schema@^7.0.9":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -468,6 +473,42 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@typescript-eslint/eslint-plugin@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.5.0.tgz#12d5f47f127af089b985f3a205c0e34a812f8fce"
+  integrity sha512-4bV6fulqbuaO9UMXU0Ia0o6z6if+kmMRW8rMRyfqXj/eGrZZRGedS4n0adeGNnjr8LKAM495hrQ7Tea52UWmQA==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "5.5.0"
+    "@typescript-eslint/scope-manager" "5.5.0"
+    debug "^4.3.2"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.1.8"
+    regexpp "^3.2.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/experimental-utils@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.5.0.tgz#3fe2514dc2f3cd95562206e4058435ea51df609e"
+  integrity sha512-kjWeeVU+4lQ1SLYErRKV5yDXbWDPkpbzTUUlfAUifPYvpX0qZlrcCZ96/6oWxt3QxtK5WVhXz+KsnwW9cIW+3A==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.5.0"
+    "@typescript-eslint/types" "5.5.0"
+    "@typescript-eslint/typescript-estree" "5.5.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/parser@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.5.0.tgz#a38070e225330b771074daa659118238793f7fcd"
+  integrity sha512-JsXBU+kgQOAgzUn2jPrLA+Rd0Y1dswOlX3hp8MuRO1hQDs6xgHtbCXEiAu7bz5hyVURxbXcA2draasMbNqrhmg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.5.0"
+    "@typescript-eslint/types" "5.5.0"
+    "@typescript-eslint/typescript-estree" "5.5.0"
+    debug "^4.3.2"
+
 "@typescript-eslint/parser@^4.20.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
@@ -486,10 +527,23 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
+"@typescript-eslint/scope-manager@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.5.0.tgz#2b9f3672fa6cddcb4160e7e8b49ef1fd00f83c09"
+  integrity sha512-0/r656RmRLo7CbN4Mdd+xZyPJ/fPCKhYdU6mnZx+8msAD8nJSP8EyCFkzbd6vNVZzZvWlMYrSNekqGrCBqFQhg==
+  dependencies:
+    "@typescript-eslint/types" "5.5.0"
+    "@typescript-eslint/visitor-keys" "5.5.0"
+
 "@typescript-eslint/types@4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+
+"@typescript-eslint/types@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.5.0.tgz#fee61ae510e84ed950a53937a2b443e078107003"
+  integrity sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg==
 
 "@typescript-eslint/typescript-estree@4.33.0":
   version "4.33.0"
@@ -504,6 +558,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.5.0.tgz#12f422698c1636bd0206086bbec9844c54625ebc"
+  integrity sha512-pVn8btYUiYrjonhMAO0yG8lm7RApzy2L4RC7Td/mC/qFkyf6vRbGyZozoA94+w6D2Y2GRqpMoCWcwx/EUOzyoQ==
+  dependencies:
+    "@typescript-eslint/types" "5.5.0"
+    "@typescript-eslint/visitor-keys" "5.5.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/visitor-keys@4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
@@ -511,6 +578,14 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.5.0.tgz#4787586897b61f26068a3db5c50b3f5d254f9083"
+  integrity sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==
+  dependencies:
+    "@typescript-eslint/types" "5.5.0"
+    eslint-visitor-keys "^3.0.0"
 
 acorn-jsx@^5.3.1:
   version "5.3.2"
@@ -1577,6 +1652,13 @@ eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
 eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
@@ -1586,6 +1668,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
+  integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
 
 eslint@7.32.0:
   version "7.32.0"
@@ -1905,7 +1992,7 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.3:
+globby@^11.0.3, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
@@ -2073,7 +2160,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4:
+ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.9"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
   integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
@@ -3308,7 +3395,7 @@ regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
-regexpp@^3.1.0:
+regexpp@^3.1.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==


### PR DESCRIPTION
The only manual fixes were around the `{}` type, which is considered invalid by recommended rules. `{}` means any non-nullish value, it is NOT an empty object.

Any items that you don't think are appropriate for this codebase (against your preferred way to do things) should be updated in the lint rules to remove any ambiguity and the code "fixes" reverted to ensure there is a clear decision with regard to the "recommendations".