### PR TITLE
fix: Show opaque background if browser does not support backdrop-filter

### DIFF
--- a/src/components/Player/PlayerFullView.scss
+++ b/src/components/Player/PlayerFullView.scss
@@ -13,12 +13,19 @@
   z-index: 1;
   
   &.is-showing {
-    backdrop-filter: blur($background-blur);
     pointer-events: all;
-    -webkit-backdrop-filter: blur($background-blur);
 
     @include themeGen() {
-      background-color: getThemeVal("backgroundTransparent");
+      background-color: getThemeVal("backgroundOpaque");
+    }
+
+    @supports(backdrop-filter: blur($background-blur)) {
+      backdrop-filter: blur($background-blur);
+      -webkit-backdrop-filter: blur($background-blur);
+
+      @include themeGen() {
+        background-color: getThemeVal("backgroundTransparent");
+      }
     }
 
     .video-player-wrapper {

--- a/styles/mixins/index.scss
+++ b/styles/mixins/index.scss
@@ -10,7 +10,9 @@
 }
 
 @mixin blurredBackground() {
-  background-color: getThemeVal("backgroundOpaque");
+  @include themeGen() {
+    background-color: getThemeVal("backgroundOpaque");
+  }
 
   @supports(backdrop-filter: blur($background-blur)) {
     backdrop-filter: blur($background-blur);

--- a/styles/mixins/index.scss
+++ b/styles/mixins/index.scss
@@ -10,6 +10,11 @@
 }
 
 @mixin blurredBackground() {
-  backdrop-filter: blur($background-blur);
-  -webkit-backdrop-filter: blur($background-blur);
+  background-color: getThemeVal("backgroundOpaque");
+
+  @supports(backdrop-filter: blur($background-blur)) {
+    backdrop-filter: blur($background-blur);
+    background-color: transparent;
+    -webkit-backdrop-filter: blur($background-blur);
+  }
 }


### PR DESCRIPTION
Hello!

First, I want to let you know I couldn't get the project running (I'm missing env vars I think, and I can't figure out to how to get Node 12 running on Apple Silicon, but that's another story 😅), so please see this PR as more of a "suggestion" than a "you should merge this". What I did might work, but **I definitely recommend you test what I did before merging and/or implement your own solution based on this PR**. I just figured a PR would be more useful than a toot 

Anyway, the issue is one that I ran into recently myself. The current version of Firefox doesn't support `backdrop-filter`, and in contexts where a modal with a translucent (or transparent) background is placed above other content, text becomes very difficult to read without it. Here's what it looks like in Firefox right now:
![image](https://user-images.githubusercontent.com/144225/145684705-f2b85974-be9b-4979-8be3-b7671bca59da.png)

The solution I went with is to use the `@supports` media query to test for `backdrop-filter` support. If the browser supports it, use the transparent or translucent background. Otherwise, use an opaque background.

Cheers!
