### PR TITLE
fix(i18n): translate categories in episodes page (page detail and fil…

### DIFF
--- a/pages/episodes.tsx
+++ b/pages/episodes.tsx
@@ -22,6 +22,7 @@ import { Page } from '~/lib/utility/page'
 import { PV } from '~/resources'
 import { isNotAllSortOption } from '~/resources/Filters'
 import { getCategoryById, getCategoryBySlug, getTranslatedCategories } from '~/services/category'
+import { translateCategoryName } from '~/lib/utility/category'
 import { getEpisodesByQuery } from '~/services/episode'
 import { getDefaultServerSideProps } from '~/services/serverSideHelpers'
 import { OmniAuralState } from '~/state/omniauralState'
@@ -80,7 +81,7 @@ export default function Episodes({
   const isCategoriesPage = filterFrom === PV.Filters.from._category && !isCategoryPage
   const isLoggedInSubscribedPage = userInfo && filterFrom === PV.Filters.from._subscribed
   const selectedCategory = isCategoryPage ? getCategoryById(filterCategoryId) : null
-  const pageHeaderText = selectedCategory ? `${t('Episodes')} > ${selectedCategory.title}` : t('Episodes')
+  const pageHeaderText = selectedCategory ? `${t('Episodes')} > ${translateCategoryName(selectedCategory.title)}` : t('Episodes')
   const showLoginMessage = !userInfo && filterFrom === PV.Filters.from._subscribed
 
   const categories = getTranslatedCategories(t)

--- a/src/lib/utility/category.tsx
+++ b/src/lib/utility/category.tsx
@@ -1,8 +1,16 @@
+import { useTranslation } from 'next-i18next'
 // import Link from 'next/link'
 
 // const getLinkCategoryHref = id => {
 //   return `/podcasts?categoryId=${id}&refresh=true`
 // }
+
+export const translateCategoryName = name => {
+  const { t } = useTranslation()
+  const translatedName = t(`category - ${name.toLowerCase()}`)
+
+  return translatedName.startsWith('category - ') ? name : translatedName
+}
 
 export const generateCategoryNodes = (categories) => {
   const categoryNodes: any[] = []
@@ -10,7 +18,7 @@ export const generateCategoryNodes = (categories) => {
   if (categories && categories.length > 0) {
     for (let i = 0; i < categories.length; i++) {
       const category = categories[i]
-      const categoryText = category.title
+      const categoryText = translateCategoryName(category.title)
       // const categoryHref = getLinkCategoryHref(category.id)
 
       categoryNodes.push(

--- a/src/services/category.tsx
+++ b/src/services/category.tsx
@@ -1,4 +1,5 @@
 import { Category } from 'podverse-shared'
+import { translateCategoryName } from '~/lib/utility/category'
 
 // eslint-disable-next-line
 const topLevelCategories = require('~/resources/Categories/TopLevelCategories')
@@ -7,13 +8,13 @@ export const getCategories = () => {
   return topLevelCategories
 }
 
-export const getTranslatedCategories = (t: any) => {
+export const getTranslatedCategories = () => {
   const translatedCategories = []
   for (const category of topLevelCategories) {
     const translatedCategory = {
       id: category.id,
       slug: category.slug,
-      title: t(`category - ${category.slug}`)
+      title: translateCategoryName(category.slug)
     }
     translatedCategories.push(translatedCategory)
   }


### PR DESCRIPTION
Fix #933

There are two scenarios:

1. Where the podcast category is present on podverse-web translation: in this case, we translate the name;
2. Where the podcast category is not present on app translation: in this case, we display it as is;

I've submitted to code review. I did not fully test it. Please don't merge yet 😅