### PR TITLE
Add styles to Episode info

### DIFF
--- a/src/components/EpisodeInfo/EpisodeInfo.scss
+++ b/src/components/EpisodeInfo/EpisodeInfo.scss
@@ -8,4 +8,14 @@
   .media-item-controls {
     margin-bottom: 27px;
   }
+
+  ul {
+    padding: 4px 0 4px 16px;
+
+    li {
+      list-style-type: circle;
+      margin: 4px 0;
+      margin-left: 12px;
+    }
+  }
 }


### PR DESCRIPTION
Is there a style guide I can follow. I am attempting to solve #1061  . I have added the same styles as seen in https://podverse.fm/tutorials  and now it looks like this.

<img width="1440" alt="Screenshot 2023-01-14 at 14 29 51" src="https://user-images.githubusercontent.com/41331326/212470524-add1caf9-2a26-4e92-9869-5bf5752f2153.png">
