### PR TITLE
Fix image 404s in manifest

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -3,12 +3,12 @@
   "short_name": "",
   "icons": [
     {
-      "src": "/android-chrome-192x192.png",
+      "src": "/images/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/android-chrome-512x512.png",
+      "src": "/images/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
These appear as an error in the console, and appear to be calling https://podverse.fm/android-chrome-192x192.png

Elsewhere in your code, you're linking to https://podverse.fm/images/android-chrome-192x192.png which *does* exist.

I figure making these changes will fix the bug, rather than me hassling you on Mastodon!