### PR TITLE
 Allow embedded player to be controlled (play, pause, seek) by page it is embedded in

### DIFF
--- a/src/components/EmbedPlayer/EmbedPlayerHeader.tsx
+++ b/src/components/EmbedPlayer/EmbedPlayerHeader.tsx
@@ -85,9 +85,9 @@ export const EmbedPlayerHeader = ({ hideFullView }: Props) => {
       switch (e.data.command) {
         case 'seek':
           let offset = e.data.parameter as number
-          if (!Number.isInteger(offset))
+          if (!Number.isFinite(offset))
           {
-            console.log(`Invalid parameter for seek command! '${e.data.parameter}' is not an integer!`);
+            console.log(`Invalid parameter for seek command! '${e.data.parameter}' is not a number!`);
             return
           }
 


### PR DESCRIPTION
Basic implementation to be able to receive commands in the embedded player.
Currently implemented: play, pause, seek

Example code (podverse-web instance needs to support this!):

```html
<script>
    function seek(position) {
        player = document.getElementById('podverse-player').contentWindow
        player.postMessage({'command': 'seek', 'parameter': position}, 'https://podverse.fm')
        player.postMessage({'command': 'play'}, '*')
    }
</script>

<iframe id="podverse-player" style="height: 170px; max-width: 600px; width: 100%; border: 0;" src="https://podverse.fm/embed/player?episodeId=GAaGekjY9" title="Podverse Embed Player" class="pv-embed-player"></iframe>

<p><a href="#" onclick="seek(90)">00:01:30</a></p>
<p><a href="#" onclick="seek(465)">00:07:45</a></p>
```

Documentation of available commands:

| command | parameter type | description
| :- | :- | :-
| play | - | start playing
| pause | - | pause player
| seek | number | seek to position in seconds specified by parameter
