### PR TITLE
Add episode download button to media item controls dropdown.

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -96,6 +96,7 @@
   "Download on the F-Droid Store": "Download on F-Droid",
   "Download on the Google Play Store": "Download on Google Play",
   "DownloadDataBackup": "Download a backup of your data.",
+  "Download Episode": "Download Episode",
   "Duration": "Duration",
   "Edit": "Edit",
   "Edit activation description - remove": "Upon activation, a button for removal appears next to each list item.",

--- a/src/components/MediaItemControls/MediaItemControls.tsx
+++ b/src/components/MediaItemControls/MediaItemControls.tsx
@@ -83,7 +83,7 @@ export const MediaItemControls = ({
     addToast(msg, {
       appearance: type,
       autoDismiss: true,
-      autoDismissTimeout: 35000,
+      autoDismissTimeout: 35000
     })
   }
 

--- a/src/components/MediaItemControls/MediaItemControls.tsx
+++ b/src/components/MediaItemControls/MediaItemControls.tsx
@@ -41,6 +41,7 @@ const _markAsPlayedKey = '_markAsPlayedKey'
 const _markAsUnplayedKey = '_markAsUnplayedKey'
 const _editClip = '_editClip'
 const _deleteClip = '_deleteClip'
+const _downloadEpisodeKey = '_downloadEpisode'
 
 export const MediaItemControls = ({
   buttonSize,
@@ -105,12 +106,32 @@ export const MediaItemControls = ({
         if (shouldDelete) {
           deleteMediaRef(nowPlayingItem.clipId)
         }
+      } else if (item.key === _downloadEpisodeKey) {
+        await _handleDownload()
       }
     }
   }
 
   const _handleTogglePlay = async () => {
     await playerTogglePlayOrLoadNowPlayingItem(nowPlayingItem)
+  }
+
+  const _handleDownload = async () => {
+    fetch(nowPlayingItem.episodeMediaUrl, {
+      method: 'GET',
+    })
+      .then(response => response.blob())
+      .then(blob => {
+        const url = window.URL.createObjectURL(new Blob([blob]))
+
+        const link = document.createElement('a')
+        link.href = url
+        link.download = nowPlayingItem.episodeTitle?.endsWith(".mp3") ? nowPlayingItem.episodeTitle : nowPlayingItem.episodeTitle + ".mp3"
+
+        document.body.appendChild(link)
+        link.click()
+        link.parentNode.removeChild(link)
+      })
   }
 
   const _handleQueueNext = async () => {
@@ -177,6 +198,7 @@ export const MediaItemControls = ({
       } else {
         items.push({ i18nKey: 'Mark as Played', key: _markAsPlayedKey })
       }
+      items.push({ i18nKey: 'Download Episode', key: _downloadEpisodeKey })
     }
 
     if (isLoggedInUserMediaRef) {


### PR DESCRIPTION
Add a dropdown on episodes to download the episode as an MP3 file.

Fixes #1099.

Tested on Linux on firefox (gecko) and ungoogled-chromium (chromium) based browsers.

# Screenshots:

## On episode page
![episode](https://github.com/podverse/podverse-web/assets/27488093/580d3148-d493-4ab1-b1ab-98cbaf99f68f)

## On episodes list
![list](https://github.com/podverse/podverse-web/assets/27488093/5db10020-0d4a-4fd6-b131-a3dd2f7cc149)

## Download on firefox
![firefox](https://github.com/podverse/podverse-web/assets/27488093/eb61fe34-3bac-4942-9038-75ecd163db24)

## Download on chrome (ungoogled-chromium)
![chrome](https://github.com/podverse/podverse-web/assets/27488093/b95ef267-77c2-492e-804c-048da4ad618e)
