### PR TITLE
Change preload to none

### DIFF
--- a/src/components/Player/PlayerAPI/PlayerAPIAudio.tsx
+++ b/src/components/Player/PlayerAPI/PlayerAPIAudio.tsx
@@ -97,6 +97,8 @@ export const PlayerAPIAudio = (props: Props) => {
     */
       preload='none'
       onEnded={_onEnded}
+      // load placeholder markers until real metadata is available
+      onLoadStart={_onLoadedMetaData}
       onLoadedMetaData={_onLoadedMetaData}
       onListen={_onListen}
       onSeeked={_onListen}

--- a/src/components/Player/PlayerAPI/PlayerAPIAudio.tsx
+++ b/src/components/Player/PlayerAPI/PlayerAPIAudio.tsx
@@ -91,8 +91,11 @@ export const PlayerAPIAudio = (props: Props) => {
       NOTE: I had to set preload to metadata to avoid bugs with WebViews
       refusing to handle changes to the <audio> currentTime properly.
       Apparently using preload auto in <audio> causes bugs in WebViews.
+
+      NOTE2: preload changed to 'none' so that only real plays are shown
+      in download numbers
     */
-      preload='metadata'
+      preload='none'
       onEnded={_onEnded}
       onLoadedMetaData={_onLoadedMetaData}
       onListen={_onListen}

--- a/src/components/TwitterCardPlayer/TwitterCardPlayerAPIAudio.tsx
+++ b/src/components/TwitterCardPlayer/TwitterCardPlayerAPIAudio.tsx
@@ -76,8 +76,11 @@ export const TwitterCardPlayerAPIAudio = ({ shouldLoadChapters }: Props) => {
         NOTE: I had to set preload to metadata to avoid bugs with WebViews
         refusing to handle changes to the <audio> currentTime properly.
         Apparently using preload auto in <audio> causes bugs in WebViews.
+
+        NOTE2: preload changed to 'none' so that only real plays are shown
+        in download numbers
       */
-      preload='metadata'
+      preload='none'
       onEnded={_onEnded}
       onLoadedMetaData={_onLoadedMetaData}
       onListen={_onListen}

--- a/src/components/TwitterCardPlayer/TwitterCardPlayerAPIAudio.tsx
+++ b/src/components/TwitterCardPlayer/TwitterCardPlayerAPIAudio.tsx
@@ -82,6 +82,8 @@ export const TwitterCardPlayerAPIAudio = ({ shouldLoadChapters }: Props) => {
       */
       preload='none'
       onEnded={_onEnded}
+      // load placeholder markers until real metadata is available
+      onLoadStart={_onLoadedMetaData}
       onLoadedMetaData={_onLoadedMetaData}
       onListen={_onListen}
       onSeeked={_onListen}

--- a/src/services/player/playerFlags.tsx
+++ b/src/services/player/playerFlags.tsx
@@ -4,6 +4,14 @@ import type { MediaRef, NowPlayingItem } from 'podverse-shared'
 import { unstable_batchedUpdates } from 'react-dom'
 
 export const generateFlagPositions = (flagTimes: number[], duration: number) => {
+  // if duration is 0, fake the locations until the data is loaded
+  if (duration === 0) {
+    const maxFlagTimes = Math.max(...flagTimes)
+    if (maxFlagTimes > 0) {
+      // add some time past the end of the last flag in case it is towards the end of the data
+      duration = maxFlagTimes + Math.floor(maxFlagTimes * 0.02)
+    }
+  }
   const flagPositions: number[] = []
   for (const flagTime of flagTimes) {
     const flagPosition = flagTime / duration


### PR DESCRIPTION
John Spurlock has brought to attention that the web player is loading the audio metadata. [1]

This makes that change.

It does mean that the clips and chapters won't load on the progress bar until the audio starts. I'm not sure if there is a way to meet the requirements to not load the file early and get them to show. 

Since JS has removed Podverse from the OP3 data because of this [2], I thought it would be better to get it fixed now and look at ways to get similar functionality from before later.

Mitch is participating in that thread so he may fix it himself. Regardless, here is a PR that makes the change.

[1] https://podcastindex.social/@js/112061341360824145

[2] https://podcastindex.social/@js/112062483844812449