### PR TITLE
fix(issue1206): Need to use unsetZIndex=true in react-draggable-list

### DIFF
--- a/pages/queue.tsx
+++ b/pages/queue.tsx
@@ -122,6 +122,7 @@ export default function Queue(props: ServerProps) {
                   itemKey={generateItemKey}
                   template={QueueListItem}
                   list={userQueueItems}
+                  unsetZIndex={true}
                   onMoveEnd={_onMoveEnd}
                   container={() => listRef.current}
                   commonProps={{ userInfo, isEditing }}


### PR DESCRIPTION
Fixes #1206
From the docs:
unsetZIndex is an optional property that defaults to false. If set to true, then the z-index of all of the list items will be set to "auto" when the list isn't animating. This may have a small performance cost when the list starts and stops animating. Use this if you need to avoid having the list item create a stacking context when it's not being animated.