### PR TITLE
fix: Add Dockerfile and documentation files to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,7 @@ temp
 
 tsconfig.tsbuildinfo
 
+Dockerfile
+Dockerfile.*
+README.md
+CHANGELOG.md


### PR DESCRIPTION
Just a couple things I do not think should be needed in the image.